### PR TITLE
Added sanity check for regex match failure.

### DIFF
--- a/npy-matlab/readNPYheader.m
+++ b/npy-matlab/readNPYheader.m
@@ -47,6 +47,9 @@ try
     % assumptions about its format...
     
     r = regexp(arrayFormat, '''descr''\s*:\s*''(.*?)''', 'tokens');
+    if isempty(r)
+        error('Couldn''t parse array format: "%s"', arrayFormat);
+    end
     dtNPY = r{1}{1};    
     
     littleEndian = ~strcmp(dtNPY(1), '>');


### PR DESCRIPTION
The array format regex failed to match when parsing NPY files generated by Open Ephys under some conditions. I've added a sanity check so that it throws a more descriptive error instead of having Matlab complain about trying to read past the end of the array.